### PR TITLE
currentStageTimeout is not calculated in OH. Using turnStartedAt instead

### DIFF
--- a/src/rankify/GameMaster.ts
+++ b/src/rankify/GameMaster.ts
@@ -1000,7 +1000,7 @@ export class GameMaster {
     // TODO: if fixed in contracts, remove this check
     const gameState = await this.getGameState({ instanceAddress, gameId });
     const lastBlock = await this.publicClient.getBlock({ blockNumber: BigInt(await this.publicClient.getBlockNumber()) });
-    if (gameState.currentPhaseTimeoutAt > lastBlock.timestamp) {
+    if (gameState.turnStartedAt + gameState.timePerTurn > lastBlock.timestamp) {
       const turnProgress = await this.getTurnProgress({ instanceAddress, gameState, gameId });
       if (turnProgress <= 100) return false;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accuracy of turn timeout detection, ensuring turns can only end after the correct time has elapsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->