### PR TITLE
Return empty array if end turn events are not found

### DIFF
--- a/.changeset/witty-crews-flash.md
+++ b/.changeset/witty-crews-flash.md
@@ -1,0 +1,5 @@
+---
+"@peeramid-labs/sdk": patch
+---
+
+Return empty array in historic turn if no endTurn event found

--- a/src/rankify/InstanceBase.ts
+++ b/src/rankify/InstanceBase.ts
@@ -95,9 +95,8 @@ export default class InstanceBase {
       },
     });
 
-    if (logsWithProposals.length !== 1 || logsWithVotesAndPermutation.length !== 1) {
-      console.error("getHistoricTurn", gameId, turnId, "failed! length: ", logsWithProposals.length, logsWithVotesAndPermutation.length);
-      throw new ApiError("Data not found", { status: 404 });
+    if (logsWithProposals.length === 0 || logsWithVotesAndPermutation.length === 0) {
+      return [];
     }
 
     const gameState = await this.getGameState(gameId);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when retrieving historic turns by ensuring an empty list is returned if expected events are missing, rather than causing errors or returning undefined. This provides more consistent and predictable behavior for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->